### PR TITLE
Fix Jazz Next post-merge review findings

### DIFF
--- a/jazz-next/src/JazzNext/Compiler/Analyzer.hs
+++ b/jazz-next/src/JazzNext/Compiler/Analyzer.hs
@@ -434,8 +434,13 @@ collectScopeDiagnostics builtinMode hiddenStatementIndices settings outerScope o
                 case Map.lookup classNameText classDeclarations of
                   Just previousSpan ->
                     ( classDeclarations,
-                      [mkDuplicateClassDeclarationError classNameText classSpan previousSpan]
+                      [mkDuplicateClassDeclarationError classNameText classSpan (Just previousSpan)]
                     )
+                  Nothing
+                    | Set.member classNameText (Set.union importedClassNames outerClassNames) ->
+                        ( classDeclarations,
+                          [mkDuplicateClassDeclarationError classNameText classSpan Nothing]
+                        )
                   Nothing ->
                     (Map.insert classNameText classSpan classDeclarations, [])
               methodErrors = duplicateClassMethodErrors classNameText methods
@@ -737,13 +742,12 @@ mkMismatchedSignatureError signatureName signatureSpan bindingName bindingSpan =
         )
     )
 
-mkDuplicateClassDeclarationError :: Text -> SourceSpan -> SourceSpan -> Diagnostic
-mkDuplicateClassDeclarationError className classSpan previousSpan =
+mkDuplicateClassDeclarationError :: Text -> SourceSpan -> Maybe SourceSpan -> Diagnostic
+mkDuplicateClassDeclarationError className classSpan maybePreviousSpan =
   setDiagnosticSubject className $
-    setDiagnosticRelatedSpan previousSpan $
-      setDiagnosticPrimarySpan
-        classSpan
-        (mkDiagnostic "E1004" ("duplicate class declaration '" <> className <> "'"))
+    maybe id setDiagnosticRelatedSpan maybePreviousSpan $
+      setDiagnosticPrimarySpan classSpan $
+        mkDiagnostic "E1004" ("duplicate class declaration '" <> className <> "'")
 
 duplicateClassMethodErrors :: Text -> [ClassMethodSignature] -> [Diagnostic]
 duplicateClassMethodErrors className methods =

--- a/jazz-next/src/JazzNext/Compiler/ModuleCompiler.hs
+++ b/jazz-next/src/JazzNext/Compiler/ModuleCompiler.hs
@@ -71,6 +71,7 @@ compilePreparedPrelude settings preparedPrelude =
               inferenceImportedTypes = Map.empty,
               inferenceImportedDataTypes = Map.empty,
               inferenceImportedCapabilities = emptyScopeCapabilityFacts,
+              inferenceImportedClassNames = Set.empty,
               inferenceCurrentModulePath = Just []
             }
           (preparedPreludeHiddenStatementIndices preparedPrelude)
@@ -126,6 +127,7 @@ compileResolvedProgram inputs resolvedProgram = do
               inferenceImportedTypes = interfaceTypeEnv importedInterface,
               inferenceImportedDataTypes = importedDataTypes importedInterface,
               inferenceImportedCapabilities = interfaceCapabilities importedInterface,
+              inferenceImportedClassNames = importedClassNames importedInterface,
               inferenceCurrentModulePath = Just modulePath
             }
           moduleExpr
@@ -164,11 +166,12 @@ dependencyImportInterface importDecl compiledModule =
 data ImportedInterface = ImportedInterface
   { importedTypes :: TypeEnv,
     importedDataTypes :: Map Text DataTypeBinding,
-    importedCapabilities :: ScopeCapabilityFacts
+    importedCapabilities :: ScopeCapabilityFacts,
+    importedClassNames :: Set.Set Text
   }
 
 emptyImportedInterface :: ImportedInterface
-emptyImportedInterface = ImportedInterface Map.empty Map.empty emptyScopeCapabilityFacts
+emptyImportedInterface = ImportedInterface Map.empty Map.empty emptyScopeCapabilityFacts Set.empty
 
 interfaceTypeEnv :: ImportedInterface -> TypeEnv
 interfaceTypeEnv = importedTypes
@@ -188,7 +191,8 @@ mergeModuleInterfaces left right =
             scopeConcreteImplFacts = Set.union (scopeConcreteImplFacts (importedCapabilities left)) (scopeConcreteImplFacts (importedCapabilities right)),
             scopeClassMethodSignatures = Map.union (scopeClassMethodSignatures (importedCapabilities left)) (scopeClassMethodSignatures (importedCapabilities right)),
             scopeConcreteImplMethods = Map.unionWith (<>) (scopeConcreteImplMethods (importedCapabilities left)) (scopeConcreteImplMethods (importedCapabilities right))
-          }
+          },
+      importedClassNames = Set.union (importedClassNames left) (importedClassNames right)
     }
 
 importWholeInterface :: ResolvedNameOrigin -> ModuleInterface -> ImportedInterface
@@ -212,7 +216,8 @@ importSelectedInterface origin maybeAlias maybeSymbols moduleInterface =
             | (dataTypeName, dataType) <- Map.toList (interfaceDataTypes moduleInterface)
           ],
       importedCapabilities =
-        rebaseCapabilityFacts origin dataTypeNames classNames selectedCapabilities
+        rebaseCapabilityFacts origin dataTypeNames classNames selectedCapabilities,
+      importedClassNames = selectedClassNames
     }
   where
     dataTypeNames = Map.keysSet (interfaceDataTypes moduleInterface)

--- a/jazz-next/src/JazzNext/Compiler/ModuleCompiler.hs
+++ b/jazz-next/src/JazzNext/Compiler/ModuleCompiler.hs
@@ -27,7 +27,6 @@ import JazzNext.Compiler.ModuleGraph
 import JazzNext.Compiler.ModuleInterface
 import JazzNext.Compiler.Name
   ( Name (..),
-    NameNamespace (..),
     ResolvedNameOrigin (..),
     identifierText,
     mkIdentifier
@@ -200,10 +199,10 @@ importSelectedInterface origin maybeAlias maybeSymbols moduleInterface =
   ImportedInterface
     { importedTypes =
         Map.fromList
-          [ ( ResolvedName origin (bindingNamespace binding) (mkIdentifier exportName),
+          [ ( ResolvedName origin (moduleExportNamespace export) (mkIdentifier (moduleExportName export)),
               rebaseTypeBinding origin dataTypeNames classNames binding
             )
-            | (exportName, binding) <- Map.toList selectedValueTypes
+            | (export, binding) <- Map.toList selectedValueTypes
           ],
       importedDataTypes =
         Map.fromList
@@ -219,7 +218,10 @@ importSelectedInterface origin maybeAlias maybeSymbols moduleInterface =
     dataTypeNames = Map.keysSet (interfaceDataTypes moduleInterface)
     classNames = Map.keysSet (interfaceClassFacts moduleInterface)
     selected name = maybe True (name `elem`) maybeSymbols
-    selectedValueTypes = Map.filterWithKey (\name _ -> selected name) (interfaceValueTypes moduleInterface)
+    selectedValueTypes =
+      Map.filterWithKey
+        (\export _ -> selected (moduleExportName export))
+        (interfaceValueTypes moduleInterface)
     includeCapabilities = maybeAlias == Nothing
     selectedClassFacts
       | includeCapabilities = Map.filterWithKey (\name _ -> selected name) (interfaceClassFacts moduleInterface)
@@ -239,12 +241,6 @@ importSelectedInterface origin maybeAlias maybeSymbols moduleInterface =
           scopeConcreteImplMethods =
             Map.filterWithKey (methodUsesClass selectedClassNames) (interfaceConcreteImplMethods moduleInterface)
         }
-
-bindingNamespace :: TypeBinding -> NameNamespace
-bindingNamespace binding =
-  case binding of
-    ConstructorTypeBinding {} -> ConstructorNamespace
-    _ -> ValueNamespace
 
 qualifiedKey :: ResolvedNameOrigin -> Text -> Text
 qualifiedKey origin name =

--- a/jazz-next/src/JazzNext/Compiler/ModuleInterface.hs
+++ b/jazz-next/src/JazzNext/Compiler/ModuleInterface.hs
@@ -6,12 +6,14 @@ module JazzNext.Compiler.ModuleInterface
     CompiledModule (..),
     CompiledPrelude (..),
     CompiledProgram (..),
+    ModuleExport (..),
     ModuleInterface (..),
     compileInputs,
     emptyCompileInputs,
     emptyCompiledPrelude,
     emptyModuleInterface,
-    lookupCompiledModule
+    lookupCompiledModule,
+    moduleExportForBinding
   ) where
 
 import Data.Map.Strict (Map)
@@ -23,17 +25,34 @@ import JazzNext.Compiler.AST (ConstraintSignatureType, Expr)
 import JazzNext.Compiler.BuiltinCatalog (BuiltinResolutionMode (ResolveKernelOnly))
 import JazzNext.Compiler.Diagnostics (Diagnostic, WarningRecord)
 import JazzNext.Compiler.ModuleGraph (ResolvedModule (resolvedModulePath))
+import JazzNext.Compiler.Name (NameNamespace (..))
 import JazzNext.Compiler.RuntimeHints (BindingRuntimeHintKey)
 import JazzNext.Compiler.TypeInference.Types
   ( ClassMethodType,
     DataTypeBinding,
     ImplMethodType,
-    TypeBinding
+    TypeBinding (..)
   )
 import JazzNext.Compiler.WarningConfig (WarningSettings)
 
+data ModuleExport = ModuleExport
+  { moduleExportNamespace :: NameNamespace,
+    moduleExportName :: Text
+  }
+  deriving (Eq, Ord, Show)
+
+moduleExportForBinding :: Text -> TypeBinding -> ModuleExport
+moduleExportForBinding exportName binding =
+  ModuleExport
+    { moduleExportNamespace =
+        case binding of
+          ConstructorTypeBinding {} -> ConstructorNamespace
+          _ -> ValueNamespace,
+      moduleExportName = exportName
+    }
+
 data ModuleInterface = ModuleInterface
-  { interfaceValueTypes :: Map Text TypeBinding,
+  { interfaceValueTypes :: Map ModuleExport TypeBinding,
     interfaceDataTypes :: Map Text DataTypeBinding,
     interfaceClassFacts :: Map Text Int,
     interfaceGeneratedEqualityClassFacts :: Set Text,

--- a/jazz-next/src/JazzNext/Compiler/ModuleResolver.hs
+++ b/jazz-next/src/JazzNext/Compiler/ModuleResolver.hs
@@ -666,6 +666,7 @@ resolveCoreModuleNames builtinMode _modulePath ambientValues ambientClasses loca
 
     importedNamespace dependencyPath nameText fallbackNamespace
       | fallbackNamespace /= ValueNamespace = fallbackNamespace
+      | Set.member nameText (Map.findWithDefault Set.empty dependencyPath valuesByModule) = ValueNamespace
       | Set.member nameText (Map.findWithDefault Set.empty dependencyPath constructorsByModule) = ConstructorNamespace
       | Set.member nameText (Map.findWithDefault Set.empty dependencyPath classesByModule) = CapabilityNamespace
       | otherwise = ValueNamespace

--- a/jazz-next/src/JazzNext/Compiler/ModuleRuntime.hs
+++ b/jazz-next/src/JazzNext/Compiler/ModuleRuntime.hs
@@ -25,6 +25,7 @@ import JazzNext.Compiler.ModuleInterface
   ( CompiledModule (..),
     CompiledPrelude (..),
     CompiledProgram (..),
+    ModuleExport (..),
     ModuleInterface (..)
   )
 import JazzNext.Compiler.Name
@@ -44,11 +45,9 @@ import JazzNext.Compiler.Runtime
     ScopeResult (..),
     evaluateModuleScope
   )
-import JazzNext.Compiler.TypeInference.Types (TypeBinding (ConstructorTypeBinding))
-
 data RuntimeModule = RuntimeModule
   { runtimeModulePath :: [Text],
-    runtimeModuleExports :: Map Text RuntimeCell
+    runtimeModuleExports :: Map ModuleExport RuntimeCell
   }
 
 data RuntimeProgram = RuntimeProgram
@@ -146,16 +145,16 @@ importRuntimeModule compiledProgram runtimeModules importDecl env =
     (Just compiledDependency, Just runtimeDependency) ->
       let interface = compiledModuleInterface compiledDependency
           selectedExports =
-            [ (exportName, cell)
-              | (exportName, cell) <- Map.toList (runtimeModuleExports runtimeDependency),
-                runtimeExportSelected importDecl interface exportName
+            [ (moduleExport, cell)
+              | (moduleExport, cell) <- Map.toList (runtimeModuleExports runtimeDependency),
+                runtimeExportSelected importDecl interface moduleExport
             ]
-          insertExport (exportName, cell) =
+          insertExport (moduleExport, cell) =
             Map.insert
               ( ResolvedName
                   (ImportedModule dependencyPath)
-                  (exportNamespace exportName interface)
-                  (mkIdentifier exportName)
+                  (moduleExportNamespace moduleExport)
+                  (mkIdentifier (moduleExportName moduleExport))
               )
               cell
        in foldr insertExport env selectedExports
@@ -169,65 +168,68 @@ importRuntimeModule compiledProgram runtimeModules importDecl env =
 publishEnvironment :: ResolvedNameOrigin -> ModuleInterface -> RuntimeEnv -> RuntimeEnv
 publishEnvironment origin moduleInterface env =
   Map.fromList
-    [ (ResolvedName origin (exportNamespace exportName moduleInterface) (mkIdentifier exportName), cell)
-      | exportName <- interfaceExportNames moduleInterface,
-        Just cell <- [lookupExportCell origin exportName moduleInterface env]
+    [ (ResolvedName origin (moduleExportNamespace moduleExport) (mkIdentifier (moduleExportName moduleExport)), cell)
+      | moduleExport <- interfaceExports moduleInterface,
+        Just cell <- [lookupExportCell origin moduleExport env]
     ]
 
-publishExports :: ResolvedNameOrigin -> ModuleInterface -> RuntimeEnv -> Map Text RuntimeCell
+publishExports :: ResolvedNameOrigin -> ModuleInterface -> RuntimeEnv -> Map ModuleExport RuntimeCell
 publishExports origin moduleInterface env =
   Map.fromList
-    [ (exportName, cell)
-      | exportName <- interfaceExportNames moduleInterface,
-        Just cell <- [lookupExportCell origin exportName moduleInterface env]
+    [ (moduleExport, cell)
+      | moduleExport <- interfaceExports moduleInterface,
+        Just cell <- [lookupExportCell origin moduleExport env]
     ]
 
-interfaceExportNames :: ModuleInterface -> [Text]
-interfaceExportNames moduleInterface =
+interfaceExports :: ModuleInterface -> [ModuleExport]
+interfaceExports moduleInterface =
   Map.keys (interfaceValueTypes moduleInterface)
-    <> Map.keys (interfaceClassMethods moduleInterface)
+    <> map (ModuleExport ValueNamespace) (Map.keys (interfaceClassMethods moduleInterface))
 
-runtimeExportSelected :: ResolvedImport -> ModuleInterface -> Text -> Bool
-runtimeExportSelected importDecl moduleInterface exportName =
+runtimeExportSelected :: ResolvedImport -> ModuleInterface -> ModuleExport -> Bool
+runtimeExportSelected importDecl moduleInterface moduleExport =
   case Map.lookup exportName (interfaceClassMethods moduleInterface) of
-    Just _ ->
-      resolvedImportAlias importDecl == Nothing
-        && maybe True classSelected (resolvedImportSymbols importDecl)
-    Nothing ->
+    Just _
+      | moduleExportNamespace moduleExport == ValueNamespace ->
+          resolvedImportAlias importDecl == Nothing
+            && maybe True classSelected (resolvedImportSymbols importDecl)
+    _ ->
       maybe True (exportName `elem`) (resolvedImportSymbols importDecl)
   where
     classSelected symbols =
       case splitQualifiedMethodKey exportName of
         Just (className, _) -> className `elem` symbols
         Nothing -> False
+    exportName = moduleExportName moduleExport
 
-lookupExportCell :: ResolvedNameOrigin -> Text -> ModuleInterface -> RuntimeEnv -> Maybe RuntimeCell
-lookupExportCell origin exportName moduleInterface env =
+lookupExportCell :: ResolvedNameOrigin -> ModuleExport -> RuntimeEnv -> Maybe RuntimeCell
+lookupExportCell origin moduleExport env =
   case Map.lookup expectedName env of
     Just cell -> Just cell
-    Nothing -> lookupRendered exportName env
+    Nothing -> lookupRendered moduleExport env
   where
+    exportName = moduleExportName moduleExport
     expectedName =
       case origin of
         AmbientPrelude -> sourceName (mkIdentifier exportName)
-        _ -> ResolvedName origin (exportNamespace exportName moduleInterface) (mkIdentifier exportName)
+        _ -> ResolvedName origin (moduleExportNamespace moduleExport) (mkIdentifier exportName)
 
-lookupRendered :: Text -> RuntimeEnv -> Maybe RuntimeCell
-lookupRendered targetName =
+lookupRendered :: ModuleExport -> RuntimeEnv -> Maybe RuntimeCell
+lookupRendered moduleExport =
   go . Map.toList
   where
+    targetName = moduleExportName moduleExport
     go entries =
       case entries of
         [] -> Nothing
         (name, cell) : rest
-          | renderName name == targetName || identifierText name == targetName -> Just cell
+          | (renderName name == targetName || identifierText name == targetName),
+            nameMatchesNamespace name -> Just cell
           | otherwise -> go rest
-
-exportNamespace :: Text -> ModuleInterface -> NameNamespace
-exportNamespace exportName moduleInterface =
-  case Map.lookup exportName (interfaceValueTypes moduleInterface) of
-    Just ConstructorTypeBinding {} -> ConstructorNamespace
-    _ -> ValueNamespace
+    nameMatchesNamespace name =
+      case name of
+        ResolvedName _ namespace _ -> namespace == moduleExportNamespace moduleExport
+        _ -> True
 
 scopeStatements :: Expr -> [Statement]
 scopeStatements expression =

--- a/jazz-next/src/JazzNext/Compiler/Runtime.hs
+++ b/jazz-next/src/JazzNext/Compiler/Runtime.hs
@@ -1015,12 +1015,17 @@ evaluateModuleScope currentModulePath evaluationMode builtinMode bindingTypeHint
       case Map.lookup methodName env of
         Just (Right (VQualifiedMethod _ classParameter methodSignature _ _)) ->
           attachRuntimeTypeHint
-            ( runtimeConstraintType methodModulePath
+            ( runtimeConstraintType signatureModulePath
                 <$> substituteClassMethodSignature classParameter implTarget methodSignature
             )
             methodValue
         _ ->
           Right methodValue
+      where
+        signatureModulePath =
+          case methodName of
+            ResolvedName (ImportedModule classModulePath) _ _ -> Just classModulePath
+            _ -> methodModulePath
 
     selectedQualifiedMethodAliasTarget :: Maybe [Text] -> Map Text Expr -> Set Text -> RuntimeEnv -> Text -> Expr -> Either Diagnostic Bool
     selectedQualifiedMethodAliasTarget methodModulePath methodExprsByKey visitedMethodKeys env methodKey expr

--- a/jazz-next/src/JazzNext/Compiler/Runtime.hs
+++ b/jazz-next/src/JazzNext/Compiler/Runtime.hs
@@ -279,7 +279,7 @@ runtimeConstructorArgument :: Maybe [Text] -> DataConstructorArgument -> DataCon
 runtimeConstructorArgument maybeModulePath argument =
   case argument of
     DataConstructorArgumentName name ->
-      DataConstructorArgumentName (runtimeDefinitionName maybeModulePath name)
+      DataConstructorArgumentName (runtimeConstraintTypeName maybeModulePath name)
     DataConstructorArgumentOpaque -> DataConstructorArgumentOpaque
 
 runtimeConstraintType :: Maybe [Text] -> ConstraintSignatureType -> ConstraintSignatureType
@@ -301,6 +301,7 @@ runtimeConstraintTypeName :: Maybe [Text] -> Name -> Name
 runtimeConstraintTypeName maybeModulePath name
   | identifierText name `elem` ["Int", "Float", "Bool"] = name
   | Just _ <- numericTypeFromName (identifierText name) = name
+  | identifierLooksLikeTypeVariable name = name
   | otherwise = runtimeDefinitionName maybeModulePath name
 
 -- | Runtime cells can hold either a value or the deterministic failure for a
@@ -992,7 +993,7 @@ evaluateModuleScope currentModulePath evaluationMode builtinMode bindingTypeHint
                     )
                 Right False ->
                   evalValueWithModulePath methodModulePath builtinMode bindingTypeHints methodEnv methodExpr
-                    >>= attachRuntimeMethodSignature methodEnv implTarget methodName
+                    >>= attachRuntimeMethodSignature methodModulePath methodEnv implTarget methodName
             insertCandidate envAcc (methodName, _, methodCandidate) =
               Map.adjust (addMethodCandidate methodCandidate) methodName envAcc
         _ -> env
@@ -1004,16 +1005,19 @@ evaluateModuleScope currentModulePath evaluationMode builtinMode bindingTypeHint
             _ -> methodCell
 
     attachRuntimeMethodSignature ::
+      Maybe [Text] ->
       RuntimeEnv ->
       ConstraintSignatureType ->
       Name ->
       RuntimeValue ->
       Either Diagnostic RuntimeValue
-    attachRuntimeMethodSignature env implTarget methodName methodValue =
+    attachRuntimeMethodSignature methodModulePath env implTarget methodName methodValue =
       case Map.lookup methodName env of
         Just (Right (VQualifiedMethod _ classParameter methodSignature _ _)) ->
           attachRuntimeTypeHint
-            (substituteClassMethodSignature classParameter implTarget methodSignature)
+            ( runtimeConstraintType methodModulePath
+                <$> substituteClassMethodSignature classParameter implTarget methodSignature
+            )
             methodValue
         _ ->
           Right methodValue

--- a/jazz-next/src/JazzNext/Compiler/TypeInference.hs
+++ b/jazz-next/src/JazzNext/Compiler/TypeInference.hs
@@ -122,7 +122,8 @@ import JazzNext.Compiler.TypeInference.Types
   )
 import JazzNext.Compiler.ModuleInterface
   ( ModuleInterface (..),
-    emptyModuleInterface
+    emptyModuleInterface,
+    moduleExportForBinding
   )
 import JazzNext.Compiler.WarningConfig
   ( WarningSettings,
@@ -243,7 +244,7 @@ moduleInterfaceFromState inputs expr state =
   emptyModuleInterface
     { interfaceValueTypes =
         Map.fromList
-          [ (renderName name, binding)
+          [ (moduleExportForBinding (renderName name) binding, binding)
             | name <- Set.toList declaredValues,
               Just binding <- [Map.lookup name (inferVisibleTypes state)]
           ],

--- a/jazz-next/src/JazzNext/Compiler/TypeInference.hs
+++ b/jazz-next/src/JazzNext/Compiler/TypeInference.hs
@@ -148,6 +148,7 @@ data InferenceInputs = InferenceInputs
     inferenceImportedTypes :: TypeEnv,
     inferenceImportedDataTypes :: Map Text DataTypeBinding,
     inferenceImportedCapabilities :: ScopeCapabilityFacts,
+    inferenceImportedClassNames :: Set Text,
     inferenceCurrentModulePath :: Maybe [Text]
   }
 
@@ -207,6 +208,7 @@ emptyInferenceInputs builtinMode settings =
       inferenceImportedTypes = Map.empty,
       inferenceImportedDataTypes = Map.empty,
       inferenceImportedCapabilities = emptyScopeCapabilityFacts,
+      inferenceImportedClassNames = Set.empty,
       inferenceCurrentModulePath = Nothing
     }
 
@@ -220,7 +222,10 @@ analysisInputsForInference inputs =
       analysisImportedClasses =
         Set.map
           (sourceName . mkIdentifier)
-          (Map.keysSet (scopeClassFacts (inferenceImportedCapabilities inputs))),
+          ( Set.union
+              (inferenceImportedClassNames inputs)
+              (Map.keysSet (scopeClassFacts (inferenceImportedCapabilities inputs)))
+          ),
       analysisModulePath = inferenceCurrentModulePath inputs
     }
 

--- a/jazz-next/test/JazzNext/Compiler/Modules/Loader/CapabilitiesTests.hs
+++ b/jazz-next/test/JazzNext/Compiler/Modules/Loader/CapabilitiesTests.hs
@@ -81,7 +81,9 @@ capabilitiesTests =
     , ("run module graph preserves imported generic constructor payload dispatch", testRunModuleGraphPreservesImportedGenericConstructorPayloadDispatch)
     , ("run module graph keeps imported ADT names in type positions", testRunModuleGraphKeepsImportedAdtNamesInTypePositions)
     , ("run module graph rebases dependency class method result hints", testRunModuleGraphRebasesDependencyClassMethodResultHints)
+    , ("run module graph rebases imported class method result hints from the class origin", testRunModuleGraphRebasesImportedClassMethodResultHintsFromClassOrigin)
     , ("compile module graph rejects classes that collide with the ambient prelude", testCompileModuleGraphRejectsAmbientClassCollision)
+    , ("compile module graph rejects classes that collide with visible imported classes", testCompileModuleGraphRejectsImportedClassCollision)
   ]
 
 testCompileModuleGraphDefaultExposesBundledCapabilityFactsInModules :: IO ()
@@ -209,7 +211,7 @@ testCompileModuleGraphKeepsModuleAdtImplFactsDistinct = do
   where
     sourceMap =
       Map.fromList
-        [ ("src/App/Main.jz", "import Lib::Box.\ndata Box a = Box a.\nclass Eq(a) { }.\nuse :: @{Eq(Box(Int))}: Int.\nuse = 1."),
+        [ ("src/App/Main.jz", "import Lib::Box (Box).\ndata Box a = Box a.\nclass Eq(a) { }.\nuse :: @{Eq(Box(Int))}: Int.\nuse = 1."),
           ("src/Lib/Box.jz", "data Box a = Box a.\nclass Eq(a) { }.\nimpl Eq(Box(Int)) { }.")
         ]
     lookupSource path = pure (Map.lookup path sourceMap)
@@ -979,6 +981,38 @@ testRunModuleGraphRebasesDependencyClassMethodResultHints = do
         ]
     lookupSource path = pure (Map.lookup path sourceMap)
 
+testRunModuleGraphRebasesImportedClassMethodResultHintsFromClassOrigin :: IO ()
+testRunModuleGraphRebasesImportedClassMethodResultHintsFromClassOrigin = do
+  result <-
+    runModuleGraphWithPrelude
+      defaultWarningSettings
+      Nothing
+      resolverConfig
+      ["App", "Main"]
+      lookupSource
+  assertEqual "compile errors" [] (runCompileErrors result)
+  case runRuntimeErrors result of
+    [diagnostic] -> do
+      assertContains "imported class result hint overflow code" "E3025" (renderDiagnostic diagnostic)
+      assertContains "imported class result hint overflow target" "outside UInt8 range" (renderDiagnostic diagnostic)
+    diagnostics ->
+      failTest
+        ( "expected one UInt8 overflow after applying the imported class method result hint, got "
+            <> Text.pack (show (map renderDiagnostic diagnostics))
+        )
+  assertEqual "runtime output" Nothing (runOutput result)
+  where
+    sourceMap =
+      Map.fromList
+        [ ( "src/App/Main.jz",
+            "module App::Main {\nimport Lib::Api.\nimpl Make(Int) {\nmake = \\(value) -> Box 1.\n}.\n(\\(Box value) -> value + 255) (Make::make 0).\n}"
+          ),
+          ( "src/Lib/Api.jz",
+            "module Lib::Api {\ndata Box = Box UInt8.\nclass Make(a) {\nmake :: a -> Box.\n}.\n}"
+          )
+        ]
+    lookupSource path = pure (Map.lookup path sourceMap)
+
 testCompileModuleGraphRejectsAmbientClassCollision :: IO ()
 testCompileModuleGraphRejectsAmbientClassCollision = do
   result <-
@@ -1003,6 +1037,38 @@ testCompileModuleGraphRejectsAmbientClassCollision = do
       Map.fromList
         [ ( "src/App/Main.jz",
             "module App::Main {\nclass Eq(a) {\nequals :: a -> a -> Bool.\n}.\n}"
+          )
+        ]
+    lookupSource path = pure (Map.lookup path sourceMap)
+
+testCompileModuleGraphRejectsImportedClassCollision :: IO ()
+testCompileModuleGraphRejectsImportedClassCollision = do
+  result <-
+    compileModuleGraphWithPrelude
+      defaultWarningSettings
+      Nothing
+      resolverConfig
+      ["App", "Main"]
+      lookupSource
+  case compileErrors result of
+    [diagnostic] ->
+      let rendered = renderDiagnostic diagnostic
+       in do
+            assertContains "imported class collision code" "E1004" rendered
+            assertContains "imported class collision summary" "duplicate class declaration 'Eq'" rendered
+    diagnostics ->
+      failTest
+        ( "expected one imported class collision, got "
+            <> Text.pack (show (map renderDiagnostic diagnostics))
+        )
+  where
+    sourceMap =
+      Map.fromList
+        [ ( "src/App/Main.jz",
+            "module App::Main {\nimport Lib::Facts (Eq).\nclass Eq(a) {\nequals :: a -> a -> Bool.\n}.\n}"
+          ),
+          ( "src/Lib/Facts.jz",
+            "module Lib::Facts {\nclass Eq(a) {\nequals :: a -> a -> Bool.\n}.\n}"
           )
         ]
     lookupSource path = pure (Map.lookup path sourceMap)

--- a/jazz-next/test/JazzNext/Compiler/Modules/Loader/CapabilitiesTests.hs
+++ b/jazz-next/test/JazzNext/Compiler/Modules/Loader/CapabilitiesTests.hs
@@ -80,6 +80,8 @@ capabilitiesTests =
     , ("run module graph exposes data referenced by imported class methods", testRunModuleGraphExposesDataReferencedByImportedClassMethods)
     , ("run module graph preserves imported generic constructor payload dispatch", testRunModuleGraphPreservesImportedGenericConstructorPayloadDispatch)
     , ("run module graph keeps imported ADT names in type positions", testRunModuleGraphKeepsImportedAdtNamesInTypePositions)
+    , ("run module graph rebases dependency class method result hints", testRunModuleGraphRebasesDependencyClassMethodResultHints)
+    , ("compile module graph rejects classes that collide with the ambient prelude", testCompileModuleGraphRejectsAmbientClassCollision)
   ]
 
 testCompileModuleGraphDefaultExposesBundledCapabilityFactsInModules :: IO ()
@@ -942,5 +944,65 @@ testRunModuleGraphKeepsImportedAdtNamesInTypePositions = do
             "module App::Main {\nimport Lib::Box.\nclass Pick(a) {\npick :: a -> Bool.\n}.\nimpl Pick(Box(UInt8)) {\npick = \\(box) -> True.\n}.\nbox = Box (__kernel_toUInt8 1).\nPick::pick box.\n}"
           ),
           ("src/Lib/Box.jz", "module Lib::Box {\ndata Box a = Box a.\n}")
+        ]
+    lookupSource path = pure (Map.lookup path sourceMap)
+
+testRunModuleGraphRebasesDependencyClassMethodResultHints :: IO ()
+testRunModuleGraphRebasesDependencyClassMethodResultHints = do
+  result <-
+    runModuleGraphWithPrelude
+      defaultWarningSettings
+      Nothing
+      resolverConfig
+      ["App", "Main"]
+      lookupSource
+  assertEqual "compile errors" [] (runCompileErrors result)
+  case runRuntimeErrors result of
+    [diagnostic] -> do
+      assertContains "rebased result hint overflow code" "E3025" (renderDiagnostic diagnostic)
+      assertContains "rebased result hint overflow target" "outside UInt8 range" (renderDiagnostic diagnostic)
+    diagnostics ->
+      failTest
+        ( "expected one UInt8 overflow after applying the method result hint, got "
+            <> Text.pack (show (map renderDiagnostic diagnostics))
+        )
+  assertEqual "runtime output" Nothing (runOutput result)
+  where
+    sourceMap =
+      Map.fromList
+        [ ( "src/App/Main.jz",
+            "module App::Main {\nimport Lib::Factory.\n(\\(Box value) -> value + 255) (Make::make 0).\n}"
+          ),
+          ( "src/Lib/Factory.jz",
+            "module Lib::Factory {\ndata Box = Box UInt8.\nclass Make(a) {\nmake :: a -> Box.\n}.\nimpl Make(Int) {\nmake = \\(value) -> Box 1.\n}.\n}"
+          )
+        ]
+    lookupSource path = pure (Map.lookup path sourceMap)
+
+testCompileModuleGraphRejectsAmbientClassCollision :: IO ()
+testCompileModuleGraphRejectsAmbientClassCollision = do
+  result <-
+    compileModuleGraph
+      defaultWarningSettings
+      resolverConfig
+      ["App", "Main"]
+      lookupSource
+  case compileErrors result of
+    [diagnostic] ->
+      let rendered = renderDiagnostic diagnostic
+       in do
+            assertContains "ambient class collision code" "E1004" rendered
+            assertContains "ambient class collision summary" "duplicate class declaration 'Eq'" rendered
+    diagnostics ->
+      failTest
+        ( "expected one ambient class collision, got "
+            <> Text.pack (show (map renderDiagnostic diagnostics))
+        )
+  where
+    sourceMap =
+      Map.fromList
+        [ ( "src/App/Main.jz",
+            "module App::Main {\nclass Eq(a) {\nequals :: a -> a -> Bool.\n}.\n}"
+          )
         ]
     lookupSource path = pure (Map.lookup path sourceMap)

--- a/jazz-next/test/JazzNext/Compiler/Modules/Loader/VisibilityTests.hs
+++ b/jazz-next/test/JazzNext/Compiler/Modules/Loader/VisibilityTests.hs
@@ -78,6 +78,7 @@ visibilityTests =
     , ("run module graph resolves qualified alias lookup through dependency export", testRunModuleGraphQualifiedAliasLookupUsesDependencyExport)
     , ("compile module graph accepts qualified alias use before import", testCompileModuleGraphQualifiedAliasLookupBeforeImport)
     , ("run module graph lets ordinary bindings shadow local constructors", testRunModuleGraphOrdinaryBindingShadowsLocalConstructor)
+    , ("run module graph imports ordinary bindings that shadow constructors", testRunModuleGraphImportsOrdinaryBindingThatShadowsConstructor)
   ]
 
 testRunModuleGraphDefaultLoadsBundledPrelude :: IO ()
@@ -743,5 +744,25 @@ testRunModuleGraphOrdinaryBindingShadowsLocalConstructor = do
     sourceMap =
       Map.fromList
         [ ("src/App/Main.jz", "module App::Main {\ndata Maybe = Just value.\nJust = 1.\nJust.\n}")
+        ]
+    lookupSource path = pure (Map.lookup path sourceMap)
+
+testRunModuleGraphImportsOrdinaryBindingThatShadowsConstructor :: IO ()
+testRunModuleGraphImportsOrdinaryBindingThatShadowsConstructor = do
+  result <-
+    runModuleGraphWithPrelude
+      defaultWarningSettings
+      Nothing
+      resolverConfig
+      ["App", "Main"]
+      lookupSource
+  assertEqual "compile errors" [] (runCompileErrors result)
+  assertEqual "runtime errors" [] (runRuntimeErrors result)
+  assertEqual "runtime output" (Just "1") (runOutput result)
+  where
+    sourceMap =
+      Map.fromList
+        [ ("src/App/Main.jz", "module App::Main {\nimport Lib::Maybe (Just).\nJust.\n}"),
+          ("src/Lib/Maybe.jz", "module Lib::Maybe {\ndata Maybe = Just value.\nJust = 1.\n}")
         ]
     lookupSource path = pure (Map.lookup path sourceMap)

--- a/jazz-next/test/JazzNext/Compiler/Modules/ModulePipelineContractSpec.hs
+++ b/jazz-next/test/JazzNext/Compiler/Modules/ModulePipelineContractSpec.hs
@@ -26,11 +26,13 @@ import JazzNext.Compiler.Runtime (renderRuntimeValue)
 import JazzNext.Compiler.ModuleInterface
   ( CompiledModule (compiledModuleInterface),
     CompiledProgram (compiledProgramErrors),
+    ModuleExport (..),
     ModuleInterface (interfaceValueTypes),
     emptyCompileInputs,
     lookupCompiledModule
   )
 import JazzNext.Compiler.BuiltinCatalog (BuiltinResolutionMode (ResolveKernelOnly))
+import JazzNext.Compiler.Name (NameNamespace (ConstructorNamespace, ValueNamespace))
 import JazzNext.Compiler.WarningConfig (defaultWarningSettings)
 import JazzNext.TestHarness
   ( NamedTest,
@@ -47,6 +49,7 @@ tests =
   [ ("dependency expressions are checked but not executed", testDependencyExpressionContract),
     ("compiled interfaces expose only declared exports", testCompiledInterfacesExposeOnlyDeclaredExports),
     ("runtime modules publish only declared exports", testRuntimeModulePublishesDeclaredExports),
+    ("module export identities distinguish shadowed values and constructors", testModuleExportIdentityPreservesNamespaces),
     ("compiled dependency terminal expressions are skipped", testCompiledDependencyTerminalExpressionIsSkipped),
     ("alias imports stay qualified", testAliasIsolationContract),
     ("transitive imports do not leak", testTransitiveVisibilityContract),
@@ -64,8 +67,50 @@ testRuntimeModulePublishesDeclaredExports = do
         Just runtimeModule ->
           assertEqual
             "export names"
-            (Set.fromList ["answer"])
+            (Set.fromList [ModuleExport ValueNamespace "answer"])
             (Map.keysSet (runtimeModuleExports runtimeModule))
+
+testModuleExportIdentityPreservesNamespaces :: IO ()
+testModuleExportIdentityPreservesNamespaces = do
+  compiled <- compileFixtureProgram shadowingSources
+  case lookupCompiledModule ["Lib", "Maybe"] compiled of
+    Nothing -> fail "missing compiled Lib::Maybe module"
+    Just compiledModule ->
+      assertEqual
+        "compiled shadowed export identities"
+        expectedExports
+        ( Map.keysSet
+            ( Map.filterWithKey
+                (\moduleExport _ -> moduleExportName moduleExport == "Just")
+                (interfaceValueTypes (compiledModuleInterface compiledModule))
+            )
+        )
+  case evaluateCompiledProgram compiled of
+    Left diagnostic -> fail ("runtime program failed: " <> Text.unpack (renderDiagnostic diagnostic))
+    Right runtime ->
+      case lookupRuntimeModule ["Lib", "Maybe"] runtime of
+        Nothing -> fail "missing runtime Lib::Maybe module"
+        Just runtimeModule ->
+          assertEqual
+            "runtime shadowed export identities"
+            expectedExports
+            ( Map.keysSet
+                ( Map.filterWithKey
+                    (\moduleExport _ -> moduleExportName moduleExport == "Just")
+                    (runtimeModuleExports runtimeModule)
+                )
+            )
+  where
+    expectedExports =
+      Set.fromList
+        [ ModuleExport ValueNamespace "Just",
+          ModuleExport ConstructorNamespace "Just"
+        ]
+    shadowingSources =
+      Map.fromList
+        [ ("src/App/Main.jz", "module App::Main { import Lib::Maybe (Just). Just. }"),
+          ("src/Lib/Maybe.jz", "module Lib::Maybe { data Maybe = Just value. Just = 1. }")
+        ]
 
 testCompiledDependencyTerminalExpressionIsSkipped :: IO ()
 testCompiledDependencyTerminalExpressionIsSkipped = do
@@ -125,7 +170,7 @@ testCompiledInterfacesExposeOnlyDeclaredExports = do
         Just compiledModule ->
           assertEqual
             "exported values"
-            (Set.fromList ["answer"])
+            (Set.fromList [ModuleExport ValueNamespace "answer"])
             (Map.keysSet (interfaceValueTypes (compiledModuleInterface compiledModule)))
       assertEqual "no compile errors" [] (compiledProgramErrors compiled)
   where


### PR DESCRIPTION
Follow-up to #95 after three new review findings arrived after that PR was merged.

## What changed

- Preserve module export namespace in a first-class `ModuleExport`, allowing ordinary values and constructors with the same spelling to cross compile-time and runtime module boundaries independently.
- Prefer an imported ordinary value over a same-name constructor in expression position while retaining constructor resolution for constructor/pattern contexts.
- Rebase class-method runtime result hints into the defining module and preserve primitive/type-parameter constructor payload names during rebasing.
- Reject module-local class declarations that collide with ambient or imported classes using `E1004`.

## Root causes

- Module interfaces and runtime export maps were keyed only by rendered text, collapsing distinct namespaces.
- The resolver reclassified value-position imports as constructors solely because a same-name constructor existed.
- Impl method signatures and constructor payload types crossed the module runtime boundary with inconsistent name origins.
- Duplicate-class analysis checked only declarations with local source spans, not visible ambient/imported class names.

## Verification

- `cabal check`
- `cabal build all`
- `cabal test all --test-show-details=never` (33 suites)
- `bash jazz-next/scripts/test-warning-config.sh`
- `bash scripts/check-docs.sh`
- `bash scripts/check-execution-queue.sh`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes post-merge findings by preserving export namespaces, correcting import resolution, and rebasing class-method result hints from the class’s origin. Prevents value/constructor name collisions and stabilizes runtime/type hinting and duplicate-class checks across modules.

- **Bug Fixes**
  - Preserve export namespaces with a first-class `ModuleExport`, so a value and a constructor named “Just” export independently at compile time and runtime.
  - Import resolution prefers an ordinary value over a same-name constructor in expression position; constructor resolution remains for constructor/pattern contexts.
  - Rebase class-method result hints from the defining class’s module and keep primitive/type-variable names intact; fixes misapplied hints in both dependency and imported-class cases (e.g., correct UInt8 overflow detection).
  - Detect duplicate class declarations that collide with ambient or imported classes and emit E1004.

- **Refactors**
  - Module interfaces and runtime exports now key by `ModuleExport`; publishing, lookup, and selection are namespace-aware.
  - Type inference and import selection build `ModuleExport` from `TypeBinding`; removed ad-hoc bindingNamespace logic.
  - Interfaces now carry imported class names for analysis; inference reads these to preserve class origins.

<sup>Written for commit 587c842d85bd6c33233f40f99e67809e4fd755a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Un3qual/jazz/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate class declaration diagnostics by linking to the earlier declaration when available.
  * Corrected handling of imported classes and namespace resolution when values and constructors share names.
  * Fixed runtime type hints and error-position rebasing for imported class methods and constructors.

* **Tests**
  * Added coverage for duplicate declarations, namespace shadowing, export identity, and imported method result hints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->